### PR TITLE
Fix Next.js config for Vercel deployment

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,20 +1,13 @@
-// next.config.js
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
     remotePatterns: [
-      { protocol: 'https', hostname: 'm.media-amazon.com' }
-    ]
-  }
-};
-module.exports = nextConfig;
-
-// next.config.js
-module.exports = {
-  images: {
-    remotePatterns: [
-      { protocol: 'https', hostname: 'm.media-amazon.com' }
+      {
+        protocol: 'https',
+        hostname: 'm.media-amazon.com',
+      },
     ],
   },
 };
 
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- clean up `next.config.js` by removing duplicate exports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'scripts/generate-products.js')*


------
https://chatgpt.com/codex/tasks/task_e_68a618eafbc083338a47a8fc7aabc648