### PR TITLE
Normalize product prices for API serialization

### DIFF
--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
   // Normalize pricing values to plain numbers for JSON serialization
   const normalized: Product[] = products.map((product: Product) => ({
     ...product,
-    price: Number(product.price?.toString()),
+    price: Number(product.price ?? 0),
   }));
 
   return NextResponse.json(normalized);

--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -5,9 +5,10 @@ import productsData from '@/data/products.json';
 const products = productsData as Product[];
 
 export async function GET() {
+  // Normalize pricing values to plain numbers for JSON serialization
   const normalized: Product[] = products.map((product: Product) => ({
     ...product,
-    price: Number(product.price),
+    price: Number(product.price?.toString()),
   }));
 
   return NextResponse.json(normalized);


### PR DESCRIPTION
## Summary
- Normalize product price fields to plain numbers before returning API results
- Document price normalization for clarity

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a66f0d3f8083338b53394e787754ab