### PR TITLE
Fix build issues and clean tsconfig

### DIFF
--- a/scripts/generate-products.js
+++ b/scripts/generate-products.js
@@ -53,7 +53,6 @@ const products = dataRows.map(line => {
 
   const numericId = Number(id);
 
-  const [id, title, description, price, active, sku, variationsRaw = ''] = parseCSVLine(line);
   return {
     id: numericId,
     slug: String(sku || '').toLowerCase(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,3 @@
-# No changes to be made, keeping the HEAD version.
 {
   "compilerOptions": {
     "target": "ES2022",


### PR DESCRIPTION
## Summary
- remove stray comment in tsconfig.json so TypeScript can resolve modules
- drop redundant CSV parse in generate-products script to avoid syntax error

## Testing
- `npm run build`
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b74db5561c8333860940e0821159b8