### PR TITLE
Fix Vercel Deployment Errors - Blog Pages

### DIFF
--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -1,4 +1,4 @@
-import { GetStaticPaths, GetStaticProps } from 'next';
+import type { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
 import Link from 'next/link';
 import fs from 'fs';
@@ -123,6 +123,5 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
         thumbnail: data.thumbnail || null,
       },
     },
-    revalidate: 60,
   };
 };

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -1,4 +1,4 @@
-import { GetStaticProps } from 'next';
+import type { GetStaticProps } from 'next';
 import Head from 'next/head';
 import Link from 'next/link';
 import fs from 'fs';
@@ -125,6 +125,5 @@ export const getStaticProps: GetStaticProps = async () => {
     props: {
       posts,
     },
-    revalidate: 60, // Revalidate every minute
   };
 };


### PR DESCRIPTION
## 🔧 Fixes Vercel Deployment Errors

This PR resolves the 7 deployment failures on Vercel by fixing TypeScript and Next.js configuration issues in the blog pages.

### Changes Made:
1. **Fixed TypeScript Import Syntax** - Changed to `import type` for Next.js types to comply with `verbatimModuleSyntax` setting
2. **Removed ISR Revalidate** - Removed `revalidate` property from `getStaticProps` which is incompatible with `output: 'export'` configuration

### Files Modified:
- `pages/blog/[slug].tsx` - Fixed type imports and removed revalidate
- `pages/blog/index.tsx` - Fixed type imports and removed revalidate

### Build Status:
✅ Build now completes successfully without errors
✅ All pages generate correctly as static HTML
✅ Blog functionality preserved

### Testing:
- Local build passes: `npm run build` ✓
- All blog pages render correctly ✓
- Static export works as expected ✓

This fix ensures your blog automation system can deploy successfully to Vercel.